### PR TITLE
Optimize FluidWalkingHandler#getFluidsEntityCanStandOn curios check

### DIFF
--- a/src/main/kotlin/dev/aaronhowser/mods/irregular_implements/handler/FluidWalkingHandler.kt
+++ b/src/main/kotlin/dev/aaronhowser/mods/irregular_implements/handler/FluidWalkingHandler.kt
@@ -49,9 +49,8 @@ object FluidWalkingHandler {
 		}
 
 		CuriosApi.getCuriosInventory(livingEntity).ifPresent {
-			for (slot in 0 until it.equippedCurios.slots) {
-				val stack = it.equippedCurios.getStackInSlot(slot)
-				fluidTags.addAll(stack.getOrDefault(ModDataComponents.CAN_STAND_ON_FLUIDS, emptyList()))
+			for (curio in it.findCurios { it.has(ModDataComponents.CAN_STAND_ON_FLUIDS) }) {
+				fluidTags.addAll(curio.stack.get(ModDataComponents.CAN_STAND_ON_FLUIDS)!!)
 			}
 		}
 


### PR DESCRIPTION
This fixes some pretty severe lag I was having in my very large modpack when sharking on water without any Irregular Implements curios equipped.

Forgive me if my Kotlin etiquette isn't up to snuff; I rarely touch the language :p